### PR TITLE
Version 3.36 update

### DIFF
--- a/proxy/gt.cpp
+++ b/proxy/gt.cpp
@@ -4,7 +4,7 @@
 #include "server.h"
 #include "utils.h"
 
-std::string gt::version = "3.35";
+std::string gt::version = "3.36";
 std::string gt::flag = "mv";
 bool gt::resolving_uid2 = false;
 bool gt::connecting = false;


### PR DESCRIPTION
3.36 was released yesterday, but the update wasn't necessary. Today players require to update to 3.36